### PR TITLE
Add qupath latest singularity recipe

### DIFF
--- a/qupath_latest.rec
+++ b/qupath_latest.rec
@@ -1,0 +1,20 @@
+Bootstrap: docker
+From: ubuntu:xenial
+
+%runscript
+    cd /qupath/QuPath/bin
+	./QuPath
+
+%post
+    mkdir /qupath
+    cd /qupath
+    apt-get update
+    apt-get install -y wget default-jre xz-utils curl
+    
+# get latest version URL from latest release on GitHub
+    LATEST_VERSION=$(curl --silent -I https://github.com/qupath/qupath/releases/latest/ | grep Location | awk -F/ '{print $NF'} | tr -d '\r')
+    wget https://github.com/qupath/qupath/releases/download/$LATEST_VERSION/QuPath-${LATEST_VERSION#v}-Linux.tar.xz
+    tar xvf QuPath-${LATEST_VERSION#v}-Linux.tar.xz
+    rm QuPath-${LATEST_VERSION#v}-Linux.tar.xz
+# set permissions to make it executable
+    chmod a+x /qupath/QuPath/bin/QuPath


### PR DESCRIPTION
This recipe when built will pull latest release off GitHub. If the naming convention changes it will break.
I based this on the existing ones, but had to make some tweaks like the folder structure and chmod.
Things to consider:
- update ubuntu?
- is default-jre still needed? there is java-19 inside the tar-file?
- rename the qupath.rec to a versioned name?
