### PR TITLE
Add qupath_plus a qupath container with DJL, StarDist, bioimage model zoo, and bio-omero

### DIFF
--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -1,0 +1,37 @@
+Bootstrap: docker
+From: amd64/ubuntu:jammy
+
+%runscript
+    cd /qupath/QuPath/bin
+    ./QuPath
+
+%post
+# install needed dependencies
+    rm -rf /var/lib/apt/lists/*
+    apt-get update -y
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+         ca-certificates \
+         wget \
+         libgl1 \
+         xz-utils \
+         openjfx \
+    
+# get QuPath 0.4.3
+    mkdir /qupath
+    chmod 777 qupath
+    cd /qupath
+    wget https://github.com/qupath/qupath/releases/download/v0.4.3/QuPath-0.4.3-Linux.tar.xz
+    tar -xvf QuPath-0.4.3-Linux.tar.xz
+    rm /qupath/QuPath-0.4.3-Linux.tar.xz
+
+# set permissions to make it executable
+    chmod a+x /qupath/QuPath/bin/QuPath
+
+# install extensions for 0.4.x
+    cd /qupath/QuPath/lib/app/
+    wget https://github.com/qupath/qupath-extension-djl/releases/download/v0.2.0/qupath-extension-djl-0.2.0.jar
+    wget https://github.com/qupath/qupath-extension-stardist/releases/download/v0.4.0/qupath-extension-stardist-0.4.0.jar
+    wget https://github.com/qupath/qupath-extension-bioimageio/releases/download/v0.1.0/qupath-extension-bioimageio-0.1.0.jar
+    sed -i '/^\[Application\]$/a app.classpath=$APPDIR/qupath-extension-djl-0.2.0.jar' QuPath.cfg
+    sed -i '/^\[Application\]$/a app.classpath=$APPDIR/qupath-extension-stardist-0.4.0.jar' QuPath.cfg
+    sed -i '/^\[Application\]$/a app.classpath=$APPDIR/qupath-extension-bioimageio-0.1.0.jar' QuPath.cfg

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -15,6 +15,7 @@ From: amd64/ubuntu:jammy
          libgl1 \
          xz-utils \
          openjfx \
+         unzip
     
 # get QuPath 0.4.3
     mkdir /qupath
@@ -30,8 +31,24 @@ From: amd64/ubuntu:jammy
 # install extensions for 0.4.x
     cd /qupath/QuPath/lib/app/
     wget https://github.com/qupath/qupath-extension-djl/releases/download/v0.2.0/qupath-extension-djl-0.2.0.jar
-    wget https://github.com/qupath/qupath-extension-stardist/releases/download/v0.4.0/qupath-extension-stardist-0.4.0.jar
-    wget https://github.com/qupath/qupath-extension-bioimageio/releases/download/v0.1.0/qupath-extension-bioimageio-0.1.0.jar
     sed -i '/^\[Application\]$/a app.classpath=$APPDIR/qupath-extension-djl-0.2.0.jar' QuPath.cfg
+
+    wget https://github.com/qupath/qupath-extension-stardist/releases/download/v0.4.0/qupath-extension-stardist-0.4.0.jar
     sed -i '/^\[Application\]$/a app.classpath=$APPDIR/qupath-extension-stardist-0.4.0.jar' QuPath.cfg
+
+    wget https://github.com/qupath/qupath-extension-bioimageio/releases/download/v0.1.0/qupath-extension-bioimageio-0.1.0.jar
     sed -i '/^\[Application\]$/a app.classpath=$APPDIR/qupath-extension-bioimageio-0.1.0.jar' QuPath.cfg
+
+    wget https://github.com/BIOP/qupath-extension-biop-omero/releases/download/v0.5.0/qupath-extension-biop-omero-0.5.0.zip
+    unzip qupath-extension-biop-omero-0.5.0.zip
+    rm qupath-extension-biop-omero-0.5.0.zip
+    wget https://github.com/ome/openmicroscopy/releases/download/v5.6.8/OMERO.java-5.6.8-ice36.zip
+    unzip OMERO.java-5.6.8-ice36.zip
+    mv OMERO.java-5.6.8-ice36/libs .
+    rm OMERO.java-5.6.8-ice36.zip
+    rm -d OMERO.java-5.6.8-ice36
+    # need to remove the extra (older) jar which causes conflicts
+    rm libs/slf4j-api.jar
+    sed -i '/^\[Application\]$/a app.classpath=$APPDIR/qupath-extension-biop-omero-0.5.0.jar' QuPath.cfg
+    sed -i '/^\[Application\]$/a app.classpath=$APPDIR/simple-omero-client-5.14.0.jar' QuPath.cfg
+    sed -i '/^\[Application\]$/a app.classpath=$APPDIR/libs/*' QuPath.cfg


### PR DESCRIPTION
This is a qupath 0.4.3 container with preinstalled extensions for 0.4.x. 
Version matching will likely need to be done manually if/when QuPath is updated.
Currently include:
- https://github.com/qupath/qupath-extension-djl
- https://github.com/qupath/qupath-extension-stardist
- https://github.com/qupath/qupath-extension-bioimageio
- https://github.com/BIOP/qupath-extension-biop-omero
These are installed directly into the app directory of QuPath.
The last one also requires OMERO Java from OME. That bundle ships a slf4j-api.jar the conflicts with one in QuPath causing errors so I've deleted it. The OMERO connection still works, everything seems fine.

PyTorch, tensorflow and models from DJL are downloaded to a . dir in ~ at runtime by DJL and persist through sessions. (However, pretrained models for Stardist need to be provided by the user.)

`From: amd64/ubuntu:jammy` : the amd64 is probably unneeded, since most builders will be amd64 anyways, however it was needed when I was building on arm64 -- the QuPath linux binary is amd64.