### PR TITLE
fiji has azul now needs fontconfig

### DIFF
--- a/ubuntu_with_fiji.rec
+++ b/ubuntu_with_fiji.rec
@@ -10,7 +10,7 @@ From:ubuntu:latest
     export MYHOME=/home/user
     mkdir $MYHOME
     apt-get update
-    apt-get -y install wget unzip xvfb libxrender1 libxtst6 libxi6
+    apt-get -y install wget unzip xvfb libxrender1 libxtst6 libxi6 fontconfig
     apt-get clean
     wget https://downloads.imagej.net/fiji/latest/fiji-linux64.zip
 	unzip fiji-linux64.zip -d $MYHOME


### PR DESCRIPTION
The builtin JRE in Fiji is now Azul which handles fonts differently.
Need to install `fontconfig` in the container to get the GUI to work.