### PR TITLE
Add xpra to qupath_plus container

### DIFF
--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -18,7 +18,7 @@ From: amd64/ubuntu:jammy
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y wget gnupg2 apt-transport-https \
     software-properties-common ca-certificates && \
     wget -O "/usr/share/keyrings/xpra.asc" https://xpra.org/xpra.asc && \
-    wget -O "/etc/apt/sources.list.d/xpra.sources" https://xpra.org/repos/jammy/xpra.sources
+    wget -O "/etc/apt/sources.list.d/xpra.sources" https://raw.githubusercontent.com/Xpra-org/xpra/master/packaging/repos/jammy/xpra.sources
 
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yqq \

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -77,7 +77,7 @@ From: amd64/ubuntu:jammy
     http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"; \
     xpra start \
     --bind-tcp=0.0.0.0:$PORT \
-    --tcp-auth=password,value=XPRA_PASSWORD \
+    --tcp-auth=password,value=$XPRA_PASSWORD \
     --html=on \
     --start="/QuPath/bin/QuPath" \
     --exit-with-client="yes" \

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -68,14 +68,16 @@ From: amd64/ubuntu:jammy
     sed -i '/^\[Application\]$/a app.classpath=$APPDIR/libs/*' QuPath.cfg
 
 %runscript
-    DISPLAY=:100
+    export DISPLAY=:100
     PORT=$(shuf -n 1 -i 9000-12000)
-    XPRA_PASSWORD=$(uuidgen)
+    export XPRA_PASSWORD=$(uuidgen)
+    echo "========================================="
     echo "Password is $XPRA_PASSWORD"
-    echo "Launching napari on Xpra. Connect via \
+    echo -e "Launching QuPath to display via Xpra. Connect via \n \
     http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
+    echo "========================================="
     xpra start \
-    --bind-tcp=0.0.0.0:$PORT,auth=password,value=$XPRA_PASSWORD \
+    --bind-tcp=0.0.0.0:$PORT,auth=env \
     --html=on \
     --start="/QuPath/bin/QuPath" \
     --exit-with-client="yes" \

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -13,6 +13,7 @@ From: amd64/ubuntu:jammy
          openjfx \
          unzip \
          curl
+         uuidgen
 
 # Install latest Xpra and dependencies
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y wget gnupg2 apt-transport-https \

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -85,13 +85,14 @@ From: amd64/ubuntu:jammy
     echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
     echo "========================================="
     xpra start \
+    --minimal=yes \  # turn off most features
     --bind-tcp=0.0.0.0:$PORT,auth=env \
+    --websocket-upgrade=yes \
+    --opengl=yes \
     --html=on \
+    --compression-level=1 \
     --start="/QuPath/bin/QuPath" \
-    --exit-with-client="yes" \
     --daemon=no \
+    --clipboard=yes \
     --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
-    --pulseaudio=no \
-    --notifications=no \
-    --bell=no \
     $DISPLAY

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -87,7 +87,8 @@ From: amd64/ubuntu:jammy
     --opengl=yes \
     --html=on \
     --compression-level=1 \
-    --start="/QuPath/bin/QuPath" \
+    --start-child="/QuPath/bin/QuPath" \
+    --exit-with-children=yes \
     --daemon=no \
     --clipboard=yes \
     --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -91,6 +91,7 @@ From: amd64/ubuntu:jammy
     --compression-level=1 \
     --start="/QuPath/bin/QuPath" \
     --exit-with-windows=yes \
+    --daemon=no \
     --clipboard=yes \
     --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
     $DISPLAY

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -71,8 +71,9 @@ From: amd64/ubuntu:jammy
     export DISPLAY=:100
     PORT=$(shuf -n 1 -i 9000-12000)
     KEY=$(uuidgen)
+    echo "AES key is $KEY"
     echo "Launching napari on Xpra. Connect via http://localhost:$PORT/?encryption=AES&keydata=$KEY \
-    or $(hostname -i):$PORT/?encryption=AES&keydata=$KEY"; \
+    or http://$(hostname -i):$PORT/?encryption=AES&keydata=$KEY"; \
     xpra start \
     --bind-tcp=0.0.0.0:$PORT,encryption=AES,keydata=$KEY \
     --html=on \

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -12,7 +12,7 @@ From: amd64/ubuntu:jammy
          xz-utils \
          openjfx \
          unzip \
-         curl
+         curl \
          uuid-runtime
 
 # Install latest Xpra and dependencies

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -74,24 +74,26 @@ From: amd64/ubuntu:jammy
 %runscript
     #!/bin/bash
     
-    export DISPLAY=:$(shuf -n 1 -i 100-200)
-    PORT=$(shuf -n 1 -i 9000-12000)
-    export XPRA_PASSWORD=$(uuidgen)
-    echo "========================================="
-    echo "Password is $XPRA_PASSWORD"
-    echo "Launching QuPath to display via Xpra on DISPLAY $DISPLAY. Connect via"
-    echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
-    echo "========================================="
-    xpra start \
-    --minimal=yes \
-    --bind-tcp=0.0.0.0:$PORT,auth=env \
-    --websocket-upgrade=yes \
-    --opengl=yes \
-    --html=on \
-    --compression-level=1 \
-    --start="/QuPath/bin/QuPath" \
-    --exit-with-windows=yes \
-    --daemon=no \
-    --clipboard=yes \
-    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
-    $DISPLAY
+export DISPLAY=:$(shuf -n 1 -i 100-200)
+PORT=$(shuf -n 1 -i 9000-12000)
+export XPRA_PASSWORD=$(uuidgen)
+echo "========================================="
+echo "Password is $XPRA_PASSWORD"
+echo "Launching QuPath to display via Xpra on DISPLAY $DISPLAY. Connect via"
+echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
+echo "Logging errors to /tmp/xpra/xpra.log"
+echo "========================================="
+xpra start \
+--minimal=yes \
+--bind-tcp=0.0.0.0:$PORT,auth=env \
+--websocket-upgrade=yes \
+--opengl=yes \
+--html=on \
+--compression-level=1 \
+--start="/QuPath/bin/QuPath" \
+--exit-with-windows=yes \
+--daemon=no \
+--clipboard=yes \
+--xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
+$DISPLAY \
+2>/tmp/xpra/xpra.log | tee /tmp/xpra/xpra.log

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -13,6 +13,7 @@ From: amd64/ubuntu:jammy
          openjfx \
          unzip \
          curl \
+         xterm \
          uuid-runtime
 
 # Install latest Xpra and dependencies
@@ -76,7 +77,7 @@ From: amd64/ubuntu:jammy
     http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"; \
     xpra start \
     --bind-tcp=0.0.0.0:$PORT \
-    --tcp-auth=env \
+    --tcp-auth=password,value=XPRA_PASSWORD \
     --html=on \
     --start="/QuPath/bin/QuPath" \
     --exit-with-client="yes" \

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -89,7 +89,6 @@ From: amd64/ubuntu:jammy
     --compression-level=1 \
     --start="/QuPath/bin/QuPath" \
     --exit-with-windows=yes \
-    --daemon=no \
     --clipboard=yes \
     --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
     $DISPLAY

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -87,8 +87,8 @@ From: amd64/ubuntu:jammy
     --opengl=yes \
     --html=on \
     --compression-level=1 \
-    --start-child="/QuPath/bin/QuPath" \
-    --exit-with-children=yes \
+    --start="/QuPath/bin/QuPath" \
+    --exit-with-windows=yes \
     --daemon=no \
     --clipboard=yes \
     --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -96,4 +96,4 @@ xpra start \
 --clipboard=yes \
 --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
 $DISPLAY \
-2>/tmp/xpra/xpra.log | tee /tmp/xpra/xpra.log
+2>/tmp/xpra/xpra.log | tee --append /tmp/xpra/xpra.log

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -68,18 +68,18 @@ From: amd64/ubuntu:jammy
     sed -i '/^\[Application\]$/a app.classpath=$APPDIR/libs/*' QuPath.cfg
 
 %runscript
-#!/bin/bash
-    export DISPLAY=:100
+    DISPLAY=:100
     PORT=$(shuf -n 1 -i 9000-12000)
     XPRA_PASSWORD=$(uuidgen)
     echo "Password is $XPRA_PASSWORD"
     echo "Launching napari on Xpra. Connect via \
-    http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"; \
+    http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
     xpra start \
     --bind-tcp=0.0.0.0:$PORT,auth=password,value=$XPRA_PASSWORD \
     --html=on \
     --start="/QuPath/bin/QuPath" \
     --exit-with-client="yes" \
+    --daemon=no \
     --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
     --pulseaudio=no \
     --notifications=no \

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -74,26 +74,26 @@ From: amd64/ubuntu:jammy
 %runscript
     #!/bin/bash
     
-export DISPLAY=:$(shuf -n 1 -i 100-200)
-PORT=$(shuf -n 1 -i 9000-12000)
-export XPRA_PASSWORD=$(uuidgen)
-echo "========================================="
-echo "Password is $XPRA_PASSWORD"
-echo "Launching QuPath to display via Xpra on DISPLAY $DISPLAY. Connect via"
-echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
-echo "Logging errors to /tmp/xpra/xpra.log"
-echo "========================================="
-xpra start \
---minimal=yes \
---bind-tcp=0.0.0.0:$PORT,auth=env \
---websocket-upgrade=yes \
---opengl=yes \
---html=on \
---compression-level=1 \
---start="/QuPath/bin/QuPath" \
---exit-with-windows=yes \
---daemon=no \
---clipboard=yes \
---xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
-$DISPLAY \
-2>/tmp/xpra/xpra.log | tee --append /tmp/xpra/xpra.log
+    export DISPLAY=:$(shuf -n 1 -i 100-200)
+    PORT=$(shuf -n 1 -i 9000-12000)
+    export XPRA_PASSWORD=$(uuidgen)
+    echo "========================================="
+    echo "Password is $XPRA_PASSWORD"
+    echo "Launching QuPath to display via Xpra on DISPLAY $DISPLAY. Connect via"
+    echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
+    echo "Logging errors to /tmp/xpra/xpra.log"
+    echo "========================================="
+    xpra start \
+    --minimal=yes \
+    --bind-tcp=0.0.0.0:$PORT,auth=env \
+    --websocket-upgrade=yes \
+    --opengl=yes \
+    --html=on \
+    --compression-level=1 \
+    --start="/QuPath/bin/QuPath" \
+    --exit-with-windows=yes \
+    --daemon=no \
+    --clipboard=yes \
+    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
+    $DISPLAY \
+    2>/tmp/xpra/xpra.log | tee --append /tmp/xpra/xpra.log

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -72,6 +72,8 @@ From: amd64/ubuntu:jammy
     sed -i '/^\[Application\]$/a app.classpath=$APPDIR/qupath-extension-omero-0.4.0.jar' QuPath.cfg
 
 %runscript
+    #!/bin/bash
+    
     export DISPLAY=:$(shuf -n 1 -i 100-200)
     PORT=$(shuf -n 1 -i 9000-12000)
     export XPRA_PASSWORD=$(uuidgen)

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -53,18 +53,26 @@ From: amd64/ubuntu:jammy
     wget https://github.com/qupath/qupath-extension-bioimageio/releases/download/v0.1.0/qupath-extension-bioimageio-0.1.0.jar
     sed -i '/^\[Application\]$/a app.classpath=$APPDIR/qupath-extension-bioimageio-0.1.0.jar' QuPath.cfg
 
-    wget https://github.com/BIOP/qupath-extension-biop-omero/releases/download/v0.8.1/qupath-extension-biop-omero-0.8.1.zip
-    unzip qupath-extension-biop-omero-0.8.1.zip
-    rm qupath-extension-biop-omero-0.8.1.zip
-    wget https://github.com/ome/openmicroscopy/releases/download/v5.6.10/OMERO.java-5.6.10-ice36.zip
-    unzip OMERO.java-5.6.10-ice36.zip
-    mv OMERO.java-5.6.10-ice36/libs .
-    rm OMERO.java-5.6.10-ice36.zip
-    rm -d OMERO.java-5.6.10-ice36
+    wget https://github.com/BIOP/qupath-extension-biop-omero/releases/download/v1.0.3/qupath-extension-biop-omero-1.0.3.zip
+    unzip qupath-extension-biop-omero-1.0.3.zip
+    rm qupath-extension-biop-omero-1.0.3.zip
+    
+    # need missing jar from 1.0.2
+    wget https://github.com/BIOP/qupath-extension-biop-omero/releases/download/v1.0.3/qupath-extension-biop-omero-1.0.2.zip
+    unzip qupath-extension-biop-omero-1.0.2.zip
+    # we don't need the 1.0.2 jar, just the simple-omero-client-5.18.0.jar
+    rm qupath-extension-biop-omero-1.0.2.jar
+    rm qupath-extension-biop-omero-1.0.2.zip
+    
+    wget https://github.com/ome/openmicroscopy/releases/download/v5.6.13/OMERO.java-5.6.13-ice36.zip
+    unzip OMERO.java-5.6.13-ice36.zip
+    mv OMERO.java-5.6.13-ice36/libs .
+    rm OMERO.java-5.6.13-ice36.zip
+    rm -d OMERO.java-5.6.13-ice36
     
     # update classpaths so the omero extension uses the app path
-    sed -i '/^\[Application\]$/a app.classpath=$APPDIR/qupath-extension-biop-omero-0.8.1.jar' QuPath.cfg
-    sed -i '/^\[Application\]$/a app.classpath=$APPDIR/simple-omero-client-5.16.0.jar' QuPath.cfg
+    sed -i '/^\[Application\]$/a app.classpath=$APPDIR/qupath-extension-biop-omero-1.0.3.jar' QuPath.cfg
+    sed -i '/^\[Application\]$/a app.classpath=$APPDIR/simple-omero-client-5.18.0.jar' QuPath.cfg
     sed -i '/^\[Application\]$/a app.classpath=$APPDIR/libs/*' QuPath.cfg
 
 %runscript
@@ -73,8 +81,8 @@ From: amd64/ubuntu:jammy
     export XPRA_PASSWORD=$(uuidgen)
     echo "========================================="
     echo "Password is $XPRA_PASSWORD"
-    echo -e "Launching QuPath to display via Xpra. Connect via \n \
-    http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
+    echo "Launching QuPath to display via Xpra. Connect via"
+    echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
     echo "========================================="
     xpra start \
     --bind-tcp=0.0.0.0:$PORT,auth=env \

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -58,7 +58,7 @@ From: amd64/ubuntu:jammy
     rm qupath-extension-biop-omero-1.0.3.zip
     
     # need missing jar from 1.0.2
-    wget https://github.com/BIOP/qupath-extension-biop-omero/releases/download/v1.0.3/qupath-extension-biop-omero-1.0.2.zip
+    wget https://github.com/BIOP/qupath-extension-biop-omero/releases/download/v1.0.2/qupath-extension-biop-omero-1.0.2.zip
     unzip qupath-extension-biop-omero-1.0.2.zip
     # we don't need the 1.0.2 jar, just the simple-omero-client-5.18.0.jar
     rm qupath-extension-biop-omero-1.0.2.jar

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -76,12 +76,12 @@ From: amd64/ubuntu:jammy
     sed -i '/^\[Application\]$/a app.classpath=$APPDIR/libs/*' QuPath.cfg
 
 %runscript
-    export DISPLAY=:100
+    export DISPLAY=:$(shuf -n 1 -i 100-200)
     PORT=$(shuf -n 1 -i 9000-12000)
     export XPRA_PASSWORD=$(uuidgen)
     echo "========================================="
     echo "Password is $XPRA_PASSWORD"
-    echo "Launching QuPath to display via Xpra. Connect via"
+    echo "Launching QuPath to display via Xpra on DISPLAY $DISPLAY. Connect via"
     echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
     echo "========================================="
     xpra start \

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -77,12 +77,11 @@ From: amd64/ubuntu:jammy
     http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"; \
     xpra start \
     --bind-tcp=0.0.0.0:$PORT \
-    --tcp-auth=password,value=$XPRA_PASSWORD \
+    --bind-tcp=0.0.0.0:$PORT,auth=password,value=$XPRA_PASSWORD \
     --html=on \
     --start="/QuPath/bin/QuPath" \
     --exit-with-client="yes" \
-    --daemon=no \
-    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 "1920x1080x24+32" -nolisten tcp -noreset" \
+    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
     --pulseaudio=no \
     --notifications=no \
     --bell=no \

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -70,12 +70,13 @@ From: amd64/ubuntu:jammy
 #!/bin/bash
     export DISPLAY=:100
     PORT=$(shuf -n 1 -i 9000-12000)
-    KEY=$(uuidgen)
-    echo "AES key is $KEY"
-    echo "Launching napari on Xpra. Connect via http://localhost:$PORT/?encryption=AES&keydata=$KEY \
-    or http://$(hostname -i):$PORT/?encryption=AES&keydata=$KEY"; \
+    XPRA_PASSWORD=$(uuidgen)
+    echo "Password is $XPRA_PASSWORD"
+    echo "Launching napari on Xpra. Connect via \
+    http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"; \
     xpra start \
-    --bind-tcp=0.0.0.0:$PORT,encryption=AES,keydata=$KEY \
+    --bind-tcp=0.0.0.0:$PORT \
+    --tcp-auth=env \
     --html=on \
     --start="/QuPath/bin/QuPath" \
     --exit-with-client="yes" \

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -57,13 +57,6 @@ From: amd64/ubuntu:jammy
     unzip qupath-extension-biop-omero-1.0.3.zip
     rm qupath-extension-biop-omero-1.0.3.zip
     
-    # need missing jar from 1.0.2
-    wget https://github.com/BIOP/qupath-extension-biop-omero/releases/download/v1.0.2/qupath-extension-biop-omero-1.0.2.zip
-    unzip qupath-extension-biop-omero-1.0.2.zip
-    # we don't need the 1.0.2 jar, just the simple-omero-client-5.18.0.jar
-    rm qupath-extension-biop-omero-1.0.2.jar
-    rm qupath-extension-biop-omero-1.0.2.zip
-    
     wget https://github.com/ome/openmicroscopy/releases/download/v5.6.13/OMERO.java-5.6.13-ice36.zip
     unzip OMERO.java-5.6.13-ice36.zip
     mv OMERO.java-5.6.13-ice36/libs .

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -68,6 +68,9 @@ From: amd64/ubuntu:jammy
     sed -i '/^\[Application\]$/a app.classpath=$APPDIR/simple-omero-client-5.18.0.jar' QuPath.cfg
     sed -i '/^\[Application\]$/a app.classpath=$APPDIR/libs/*' QuPath.cfg
 
+    wget https://github.com/qupath/qupath-extension-omero-web/releases/download/v0.4.0/qupath-extension-omero-0.4.0.jar
+    sed -i '/^\[Application\]$/a app.classpath=$APPDIR/qupath-extension-omero-0.4.0.jar' QuPath.cfg
+
 %runscript
     export DISPLAY=:$(shuf -n 1 -i 100-200)
     PORT=$(shuf -n 1 -i 9000-12000)
@@ -78,7 +81,7 @@ From: amd64/ubuntu:jammy
     echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
     echo "========================================="
     xpra start \
-    --minimal=yes \  # turn off most features
+    --minimal=yes \
     --bind-tcp=0.0.0.0:$PORT,auth=env \
     --websocket-upgrade=yes \
     --opengl=yes \

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -1,10 +1,6 @@
 Bootstrap: docker
 From: amd64/ubuntu:jammy
 
-%runscript
-    cd /QuPath/bin
-    ./QuPath
-
 %post
 # install needed dependencies
     rm -rf /var/lib/apt/lists/*
@@ -18,7 +14,23 @@ From: amd64/ubuntu:jammy
          unzip \
          curl
 
-# get latest version URL from latest release on GitHub
+# Install latest Xpra and dependencies
+    apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y wget gnupg2 apt-transport-https \
+    software-properties-common ca-certificates && \
+    wget -O "/usr/share/keyrings/xpra.asc" https://xpra.org/xpra.asc && \
+    wget -O "/etc/apt/sources.list.d/xpra.sources" https://xpra.org/repos/jammy/xpra.sources
+
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yqq \
+    xpra \
+    xvfb \
+    xterm \
+    sshfs && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+
+# Install latest QuPath release from GitHub
     LATEST_VERSION=$(curl --silent -I https://github.com/qupath/qupath/releases/latest/ | grep location | awk -F/ '{print $NF'} | tr -d '\r')
     wget https://github.com/qupath/qupath/releases/download/$LATEST_VERSION/QuPath-${LATEST_VERSION}-Linux.tar.xz
     tar xvf QuPath-${LATEST_VERSION}-Linux.tar.xz
@@ -52,3 +64,22 @@ From: amd64/ubuntu:jammy
     sed -i '/^\[Application\]$/a app.classpath=$APPDIR/qupath-extension-biop-omero-0.8.1.jar' QuPath.cfg
     sed -i '/^\[Application\]$/a app.classpath=$APPDIR/simple-omero-client-5.16.0.jar' QuPath.cfg
     sed -i '/^\[Application\]$/a app.classpath=$APPDIR/libs/*' QuPath.cfg
+
+%runscript
+#!/bin/bash
+    export DISPLAY=:100
+    PORT=$(shuf -n 1 -i 9000-12000)
+    KEY=$(uuidgen)
+    echo "Launching napari on Xpra. Connect via http://localhost:$PORT/?encryption=AES&keydata=$KEY \
+    or $(hostname -i):$PORT/?encryption=AES&keydata=$KEY"; \
+    xpra start \
+    --bind-tcp=0.0.0.0:$PORT,encryption=AES,keydata=$KEY \
+    --html=on \
+    --start="/QuPath/bin/QuPath" \
+    --exit-with-client="yes" \
+    --daemon=no \
+    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 "1920x1080x24+32" -nolisten tcp -noreset" \
+    --pulseaudio=no \
+    --notifications=no \
+    --bell=no \
+    $DISPLAY

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -13,7 +13,7 @@ From: amd64/ubuntu:jammy
          openjfx \
          unzip \
          curl
-         uuidgen
+         uuid-runtime
 
 # Install latest Xpra and dependencies
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y wget gnupg2 apt-transport-https \

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -76,7 +76,6 @@ From: amd64/ubuntu:jammy
     echo "Launching napari on Xpra. Connect via \
     http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"; \
     xpra start \
-    --bind-tcp=0.0.0.0:$PORT \
     --bind-tcp=0.0.0.0:$PORT,auth=password,value=$XPRA_PASSWORD \
     --html=on \
     --start="/QuPath/bin/QuPath" \


### PR DESCRIPTION
So QuPath, due to modern JavaFX doesn't work through X11.
This PR adds Xpra (https://github.com/Xpra-org/xpra) to the container and uses that as the remote windowing.
The runscript has the details.
I pick a random port -- alas, trying to validate it failed because I couldn't see host ports from inside the container. Could work around this by launching using a bash script from outside the container.
I ran into some issues with the runscript, that I didn't have when using 2 containers (xpra and qupath)
I tried to secure using AES encryption, but got seg faults, so using password. The password is passed using env var so it's not shown in `ps` list.
Also, I tried running as a daemon to not get so much spam in the terminal, but that resulted in an xpra error -- but only when launched from the runscript :shrug:

Other than that, it's just a 1920x1080x24+32 virtual frame buffer and then it can be accessed via Xpra client or web browser.

I also updated the omero plugin in the container.
