### PR TITLE
Update qupath_plus.def to fix log location

### DIFF
--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -81,7 +81,7 @@ From: amd64/ubuntu:jammy
     echo "Password is $XPRA_PASSWORD"
     echo "Launching QuPath to display via Xpra on DISPLAY $DISPLAY. Connect via"
     echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
-    echo "Logging errors to /tmp/xpra/xpra.log"
+    echo "Logging errors to /tmp/xpra.log"
     echo "========================================="
     xpra start \
     --minimal=yes \


### PR DESCRIPTION
Ethan reported that he got a `no such file` error for the log location, which was `/tmp/xpra/` I guess i had that created from some other testing. Switching to `/tmp`