### PR TITLE
Update qupath xpra to do port checking using netcat

### DIFF
--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -8,7 +8,7 @@ From: amd64/ubuntu:jammy
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
          ca-certificates \
          wget \
-         nc \
+         netcat \
          libgl1 \
          xz-utils \
          openjfx \

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -75,7 +75,7 @@ From: amd64/ubuntu:jammy
     #!/bin/bash
     
     export DISPLAY=:$(shuf -n 1 -i 100-200)
-    PORT=$(shuf -n 1 -i 9000-12000)
+    while PORT=$(shuf -n 1 -i 49152-65535); nc -z 0.0.0.0 $PORT; do continue; done
     export XPRA_PASSWORD=$(uuidgen)
     echo "========================================="
     echo "Password is $XPRA_PASSWORD"

--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -8,6 +8,7 @@ From: amd64/ubuntu:jammy
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
          ca-certificates \
          wget \
+         nc \
          libgl1 \
          xz-utils \
          openjfx \


### PR DESCRIPTION
This was a suggestion by Glenn @ggaffield

I had to install netcat in the container, but it now works.
e.g.
```
[sobolp@sumner123 containers]
$ ./qupath_plus_x.sif 
=========================================
Password is 227a0b80-5336-436c-b8fd-49549c0fb0c0
Launching QuPath to display via Xpra on DISPLAY :179. Connect via
http://10.5.37.123:51338/?password=227a0b80-5336-436c-b8fd-49549c0fb0c0
Logging errors to /tmp/xpra.log
```