### PR TITLE
create a run/user xdg dir that is accessible to things running in the container

### DIFF
--- a/qupath_plus.def
+++ b/qupath_plus.def
@@ -74,7 +74,9 @@ From: amd64/ubuntu:jammy
 
 %runscript
     #!/bin/bash
-    
+    mkdir -p $HOME/.xpra
+    chmod 700 $HOME/.xpra
+    export XDG_RUNTIME_DIR=$HOME/.xpra
     export DISPLAY=:$(shuf -n 1 -i 100-200)
     while PORT=$(shuf -n 1 -i 49152-65535); nc -z 0.0.0.0 $PORT; do continue; done
     export XPRA_PASSWORD=$(uuidgen)
@@ -88,6 +90,7 @@ From: amd64/ubuntu:jammy
     --minimal=yes \
     --bind-tcp=0.0.0.0:$PORT,auth=env \
     --websocket-upgrade=yes \
+    --socket-dirs=$XDG_RUNTIME_DIR \
     --opengl=yes \
     --html=on \
     --compression-level=1 \


### PR DESCRIPTION
This silences a bunch of warnings related to permissions in /etc

The current output (if you don't redirect sterr)

```
[sobolp@sumner123 containers]
$ ./qupath_plus_x.sif 
=========================================
Password is 430f2ea2-0d18-453d-ada3-5675a8c0a102
Launching QuPath to display via Xpra on DISPLAY :152. Connect via
http://10.5.37.123:64487/?password=430f2ea2-0d18-453d-ada3-5675a8c0a102
Logging errors to /tmp/xpra.log
=========================================
2024-12-05 12:24:08,794 created tcp socket '0.0.0.0:64487'
2024-12-05 12:24:08,835 no uinput module (not usually needed)
_XSERVTransmkdir: Owner of /tmp/.X11-unix should be set to root
2024-12-05 12:24:10,205 pointer device emulation using XTest
2024-12-05 12:24:10,210 wrote pid 829777 to '/home/sobolp/.xpra/xpra/152/server.pid'
2024-12-05 12:24:10,210 serving html content from '/usr/share/xpra/www'
2024-12-05 12:24:10,245 created unix domain sockets:
2024-12-05 12:24:10,245  '/home/sobolp/.xpra/sumner123-152'
2024-12-05 12:24:10,245  '/home/sobolp/.xpra/xpra/152/socket'
2024-12-05 12:24:10,245 created abstract sockets:
2024-12-05 12:24:10,245  '@xpra/152'
2024-12-05 12:24:10,245 xvfb pid 829783
2024-12-05 12:24:10,289 Warning: cannot set resolution to (8192, 4096)
2024-12-05 12:24:10,289  (this resolution is not available)
2024-12-05 12:24:10,396 187.6GB of system memory
2024-12-05 12:24:10,412 xpra is ready.
2024-12-05 12:24:10,412 xpra X11 seamless server version 6.2.1-r0
2024-12-05 12:24:10,413  uid=63701 (sobolp), gid=10000 (jaxuser)
2024-12-05 12:24:10,413  running with pid 829777 on Linux Ubuntu 22.04 jammy
2024-12-05 12:24:10,413  cpython 3.10
2024-12-05 12:24:10,414  connected to X11 display :152 with 24 bit colors
2024-12-05 12:24:10,416 No OpenGL_accelerate module loaded: No module named 'OpenGL_accelerate'
2024-12-05 12:24:11,202 OpenGL is supported on display ':152'
2024-12-05 12:24:11,202  using 'llvmpipe (LLVM 15.0.7, 256 bits)' renderer
2024-12-05 12:24:11,203 started command `/QuPath/bin/QuPath` with pid 829811
2024-12-05 12:24:11,207  wrote pid 829811 to '/home/sobolp/.xpra/xpra/152/QuPath.pid'
2024-12-05 12:24:11,212 started command `ibus-daemon` with pid 829815
2024-12-05 12:24:11,215  wrote pid 829815 to '/home/sobolp/.xpra/xpra/152/ibus-daemon.pid'
Dec 05, 2024 5:24:13 PM com.sun.javafx.application.PlatformImpl startup
WARNING: Unsupported JavaFX configuration: classes were loaded from 'unnamed module @55536d9e'
17:24:13.845 [JavaFX Application Thread] [INFO ] qupath.lib.gui.QuPathGUI - Initializing: 1733419453845
17:24:13.975 [JavaFX Application Thread] [INFO ] qupath.lib.gui.prefs.PathPrefs - Setting default Locale to en_US
17:24:13.976 [JavaFX Application Thread] [INFO ] qupath.lib.gui.prefs.PathPrefs - Setting Locale for FORMAT to en_US
17:24:13.976 [JavaFX Application Thread] [INFO ] qupath.lib.gui.prefs.PathPrefs - Setting Locale for DISPLAY to en_US
17:24:13.982 [JavaFX Application Thread] [INFO ] qupath.lib.common.ThreadTools - Setting parallelism to 3
17:24:14.224 [JavaFX Application Thread] [INFO ] q.l.g.i.s.ImageRegionStoreFactory - Setting tile cache size to 24016.00 MB (25.0% max memory)
17:24:14.830 [JavaFX Application Thread] [INFO ] qupath.lib.gui.QuPathGUI - QuPath build: Version: 1.0.3
Build time: 2024-08-23, 11:37
17:24:16.637 [JavaFX Application Thread] [INFO ] qupath.lib.scripting.QP - Initializing type adapters
Warning: Versions of org.bytedeco:javacpp:1.5.9 and org.bytedeco:opencv:4.6.0-1.5.8 do not match.
Warning: Versions of org.bytedeco:javacpp:1.5.9 and org.bytedeco:openblas:0.3.21-1.5.8 do not match.
2024-12-05 12:24:16,760 Error parsing xdg menu data:
2024-12-05 12:24:16,761  ParsingError in file '/etc/xdg/menus/debian-menu.menu', File not found
2024-12-05 12:24:16,761  this is either a bug in python-xdg,
2024-12-05 12:24:16,761  or an invalid system menu configuration
2024-12-05 12:24:16,761  for more information, please see:
2024-12-05 12:24:16,761  https://github.com/Xpra-org/xpra/issues/2174
```

Only the `xdg-menu` remains. This is how start-like menu items are discovered for desktop environments. `menus` isn't installed in base ubuntu and there is nothing to put in the menu in this use case anyway, so I think it's fine to ignore.