### PR TITLE
Update fiji download link

### DIFF
--- a/fiji_latest.def
+++ b/fiji_latest.def
@@ -12,9 +12,9 @@ From:amd64/ubuntu:jammy
     apt-get update
     apt-get -y install wget unzip xvfb libxrender1 libxtst6 libxi6 fontconfig
     apt-get clean
-    wget https://downloads.imagej.net/fiji/latest/fiji-linux64.zip
-	unzip fiji-linux64.zip -d $MYHOME
-	rm fiji-linux64.zip
+    wget https://downloads.imagej.net/fiji/stable/fiji-stable-linux64-jdk.zip
+	unzip fiji-stable-linux64-jdk.zip -d $MYHOME
+	rm fiji-stable-linux64-jdk.zip
 	export PATH=$MYHOME/Fiji.app:$PATH 
 	echo "export PATH=$MYHOME/Fiji.app:$PATH" >> "$SINGULARITY_ENVIRONMENT"
 	cd $MYHOME

--- a/fiji_xpra.def
+++ b/fiji_xpra.def
@@ -59,7 +59,7 @@ From:amd64/ubuntu:jammy
     --opengl=yes \
     --html=on \
     --compression-level=1 \
-    --start="ImageJ-linux64" \
+    --start="fiji" \
     --exit-with-windows=yes \
     --daemon=no \
     --clipboard=yes \

--- a/fiji_xpra.def
+++ b/fiji_xpra.def
@@ -8,9 +8,9 @@ From:amd64/ubuntu:jammy
     apt-get update
     apt-get -y install wget unzip xvfb libxrender1 libxtst6 libxi6 fontconfig
     apt-get clean
-    wget https://downloads.imagej.net/fiji/latest/fiji-linux64.zip
-    unzip fiji-linux64.zip -d $MYHOME
-    rm fiji-linux64.zip
+    wget https://downloads.imagej.net/fiji/stable/fiji-stable-linux64-jdk.zip
+    unzip fiji-stable-linux64-jdk.zip -d $MYHOME
+    rm fiji-stable-linux64-jdk.zip
     export PATH=$MYHOME/Fiji.app:$PATH 
     echo "export PATH=$MYHOME/Fiji.app:$PATH" >> "$SINGULARITY_ENVIRONMENT"
     cd $MYHOME


### PR DESCRIPTION
There's been some changes to the Fiji download locations and zip file naming.
- latest now uses Java21, which is still a bit experimental, so will use `stable` for Java8
- Now you need to pick jdk vs jre. SeE: https://forum.image.sc/t/differences-between-jre-and-jdk/112313/15
   - I went with JDK which is what was previously bundled.
- with xpra we can safely run the actual Fiji app, so updated the runscript for that.
- tested this on sumner2 and it works nicely.