### PR TITLE
Update fiji_xpra

### DIFF
--- a/fiji_xpra.def
+++ b/fiji_xpra.def
@@ -42,6 +42,7 @@ From:amd64/ubuntu:jammy
     mkdir -p $HOME/.xpra
     chmod 700 $HOME/.xpra
     export XDG_RUNTIME_DIR=$HOME/.xpra
+    export JAVA_TOOL_OPTIONS="-Djava.util.prefs.userRoot=$HOME/.xpra"
     export DISPLAY=:$(shuf -n 1 -i 100-200)
     while PORT=$(shuf -n 1 -i 49152-65535); nc -z 0.0.0.0 $PORT; do continue; done
     export XPRA_PASSWORD=$(uuidgen)

--- a/fiji_xpra.def
+++ b/fiji_xpra.def
@@ -41,7 +41,7 @@ From:amd64/ubuntu:jammy
     #!/bin/bash
     # setup secure DISPLAY
     export DISPLAY=:$(shuf -n 1 -i 100-200)
-    export XAUTHORITY="${HOME}/.Xauthor?ty"
+    export XAUTHORITY="${HOME}/.Xauthority"
     xauth add ${DISPLAY} . "$(mcookie)"
     mkdir -p $HOME/.xpra
     chmod 700 $HOME/.xpra

--- a/fiji_xpra.def
+++ b/fiji_xpra.def
@@ -39,11 +39,14 @@ From:amd64/ubuntu:jammy
 
 %runscript
     #!/bin/bash
+    # setup secure DISPLAY
+    export DISPLAY=:$(shuf -n 1 -i 100-200)
+    export XAUTHORITY="${HOME}/.Xauthor?ty"
+    xauth add ${DISPLAY} . "$(mcookie)"
     mkdir -p $HOME/.xpra
     chmod 700 $HOME/.xpra
     export XDG_RUNTIME_DIR=$HOME/.xpra
     export JAVA_TOOL_OPTIONS="-Djava.util.prefs.userRoot=$HOME/.xpra"
-    export DISPLAY=:$(shuf -n 1 -i 100-200)
     while PORT=$(shuf -n 1 -i 49152-65535); nc -z 0.0.0.0 $PORT; do continue; done
     export XPRA_PASSWORD=$(uuidgen)
     echo "========================================="


### PR DESCRIPTION
This PR adresses the annoying java.util.Prefs throwing BackingStoreException that would pop the console and interrupt work. The fix was to set a writable location for the java preferences.
Additionally it fixes Xauth to use the magic cookie, so -x is no longer required on interactive sessions.