### PR TITLE
Tweak xpra parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To run a container you need to have the module loaded on a compute node. You can
 ```bash
 ./qupath_0_6_0.sif
 ```
-For the Xpra-enabled containers, the virtual display starts at `1920x1080` and then resizes to match the attached browser session. Set `XPRA_INITIAL_RESOLUTION=WIDTHxHEIGHT` before launching if you want a different starting size.
+For the Xpra-enabled containers, `xpra` now manages the virtual X server directly instead of hard-coding a `1920x1080` framebuffer. The application starts after the first browser client connects, so the virtual display can size to the browser without forcing lower-resolution users to start on a giant display.
 
 We also provide a convenience script to start a batch job with your container: `./spin_container.sh`. 
 As long as your built container is in the same directory, you're good to go. By default, it will run as a job on a 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ To run a container you need to have the module loaded on a compute node. You can
 ```bash
 ./qupath_0_6_0.sif
 ```
+For the Xpra-enabled containers, the virtual display starts at `1920x1080` and then resizes to match the attached browser session. Set `XPRA_INITIAL_RESOLUTION=WIDTHxHEIGHT` before launching if you want a different starting size.
+
 We also provide a convenience script to start a batch job with your container: `./spin_container.sh`. 
 As long as your built container is in the same directory, you're good to go. By default, it will run as a job on a 
 single core, with 4GB RAM for 10 minutes.
@@ -75,4 +77,3 @@ We have two scripts: `open_container.sh` and `spin_container.sh`. You shouldn't 
 -c  How many cores your job will use (default: 1)
 -m  How much memory will be allocated for your job (default: 4GB)
 ```
-

--- a/fiji_xpra.def
+++ b/fiji_xpra.def
@@ -57,22 +57,23 @@ From:amd64/ubuntu:jammy
     echo "Logging errors to $XPRA_LOG"
     echo "========================================="
     xpra start \
-    --minimal=yes \
     --bind-tcp=0.0.0.0:$PORT,auth=env \
-    --websocket-upgrade=yes \
+    --mdns=no \
     --socket-dirs=$XDG_RUNTIME_DIR \
-    --opengl=yes \
     --html=on \
     --resize-display=yes \
-    --compression-level=1 \
-    --pings=5 \
-    --encodings=rgb,png,jpeg,webp \
-    --mousewheel=on \
-    --cursors=yes \
+    --dpi=96 \
+    --file-transfer=no \
+    --open-files=no \
+    --open-url=no \
+    --printing=no \
+    --webcam=no \
+    --notifications=no \
+    --system-tray=no \
+    --audio=no \
     --start-child-after-connect="fiji" \
     --exit-with-windows=yes \
     --daemon=no \
-    --clipboard=yes \
     --xvfb="Xvfb" \
     $DISPLAY \
     2>"$XPRA_LOG" | tee --append "$XPRA_LOG"

--- a/fiji_xpra.def
+++ b/fiji_xpra.def
@@ -47,12 +47,14 @@ From:amd64/ubuntu:jammy
     chmod 700 $HOME/.xpra
     export XDG_RUNTIME_DIR=$HOME/.xpra
     export JAVA_TOOL_OPTIONS="-Djava.util.prefs.userRoot=$HOME/.xpra"
+    export XPRA_INITIAL_RESOLUTION="${XPRA_INITIAL_RESOLUTION:-1920x1080}"
     while PORT=$(shuf -n 1 -i 49152-65535); nc -z 0.0.0.0 $PORT; do continue; done
     export XPRA_PASSWORD=$(uuidgen)
     echo "========================================="
     echo "Password is $XPRA_PASSWORD"
     echo "Launching Fiji to display via Xpra on DISPLAY $DISPLAY. Connect via"
     echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
+    echo "Initial Xpra display size is $XPRA_INITIAL_RESOLUTION and it will resize to the client."
     echo "Logging errors to /tmp/xpra.log"
     echo "========================================="
     xpra start \
@@ -62,11 +64,12 @@ From:amd64/ubuntu:jammy
     --socket-dirs=$XDG_RUNTIME_DIR \
     --opengl=yes \
     --html=on \
+    --resize-display=$XPRA_INITIAL_RESOLUTION \
     --compression-level=1 \
     --start="fiji" \
     --exit-with-windows=yes \
     --daemon=no \
     --clipboard=yes \
-    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
+    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 ${XPRA_INITIAL_RESOLUTION}x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
     $DISPLAY \
     2>/tmp/xpra.log | tee --append /tmp/xpra.log

--- a/fiji_xpra.def
+++ b/fiji_xpra.def
@@ -41,21 +41,20 @@ From:amd64/ubuntu:jammy
     #!/bin/bash
     # setup secure DISPLAY
     export DISPLAY=:$(shuf -n 1 -i 100-200)
-    export XAUTHORITY="${HOME}/.Xauthority"
-    xauth add ${DISPLAY} . "$(mcookie)"
     mkdir -p $HOME/.xpra
     chmod 700 $HOME/.xpra
     export XDG_RUNTIME_DIR=$HOME/.xpra
+    export XPRA_PRIVATE_XAUTH=1
+    export XPRA_LOG="$XDG_RUNTIME_DIR/xpra-fiji.log"
     export JAVA_TOOL_OPTIONS="-Djava.util.prefs.userRoot=$HOME/.xpra"
-    export XPRA_INITIAL_RESOLUTION="${XPRA_INITIAL_RESOLUTION:-1920x1080}"
     while PORT=$(shuf -n 1 -i 49152-65535); nc -z 0.0.0.0 $PORT; do continue; done
     export XPRA_PASSWORD=$(uuidgen)
     echo "========================================="
     echo "Password is $XPRA_PASSWORD"
     echo "Launching Fiji to display via Xpra on DISPLAY $DISPLAY. Connect via"
     echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
-    echo "Initial Xpra display size is $XPRA_INITIAL_RESOLUTION and it will resize to the client."
-    echo "Logging errors to /tmp/xpra.log"
+    echo "Fiji will start after the first client connects so the display can size to the browser."
+    echo "Logging errors to $XPRA_LOG"
     echo "========================================="
     xpra start \
     --minimal=yes \
@@ -64,12 +63,16 @@ From:amd64/ubuntu:jammy
     --socket-dirs=$XDG_RUNTIME_DIR \
     --opengl=yes \
     --html=on \
-    --resize-display=$XPRA_INITIAL_RESOLUTION \
+    --resize-display=yes \
     --compression-level=1 \
-    --start="fiji" \
+    --pings=5 \
+    --encodings=rgb,png,jpeg,webp \
+    --mousewheel=on \
+    --cursors=yes \
+    --start-child-after-connect="fiji" \
     --exit-with-windows=yes \
     --daemon=no \
     --clipboard=yes \
-    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 ${XPRA_INITIAL_RESOLUTION}x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
+    --xvfb="Xvfb" \
     $DISPLAY \
-    2>/tmp/xpra.log | tee --append /tmp/xpra.log
+    2>"$XPRA_LOG" | tee --append "$XPRA_LOG"

--- a/qupath_plus_051.def
+++ b/qupath_plus_051.def
@@ -76,18 +76,17 @@ From: amd64/ubuntu:jammy
     mkdir -p $HOME/.xpra
     chmod 700 $HOME/.xpra
     export XDG_RUNTIME_DIR=$HOME/.xpra
+    export XPRA_PRIVATE_XAUTH=1
+    export XPRA_LOG="$XDG_RUNTIME_DIR/xpra-qupath-plus.log"
     export DISPLAY=:$(shuf -n 1 -i 100-200)
-    export XAUTHORITY="${HOME}/.Xauthority"
-    xauth add ${DISPLAY} . "$(mcookie)"
-    export XPRA_INITIAL_RESOLUTION="${XPRA_INITIAL_RESOLUTION:-1920x1080}"
     while PORT=$(shuf -n 1 -i 49152-65535); nc -z 0.0.0.0 $PORT; do continue; done
     export XPRA_PASSWORD=$(uuidgen)
     echo "========================================="
     echo "Password is $XPRA_PASSWORD"
     echo "Launching QuPath to display via Xpra on DISPLAY $DISPLAY. Connect via"
     echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
-    echo "Initial Xpra display size is $XPRA_INITIAL_RESOLUTION and it will resize to the client."
-    echo "Logging errors to /tmp/xpra.log"
+    echo "QuPath will start after the first client connects so the display can size to the browser."
+    echo "Logging errors to $XPRA_LOG"
     echo "========================================="
     xpra start \
     --minimal=yes \
@@ -96,12 +95,16 @@ From: amd64/ubuntu:jammy
     --socket-dirs=$XDG_RUNTIME_DIR \
     --opengl=yes \
     --html=on \
-    --resize-display=$XPRA_INITIAL_RESOLUTION \
+    --resize-display=yes \
     --compression-level=1 \
-    --start="/QuPath/bin/QuPath" \
+    --pings=5 \
+    --encodings=rgb,png,jpeg,webp \
+    --mousewheel=on \
+    --cursors=yes \
+    --start-child-after-connect="/QuPath/bin/QuPath" \
     --exit-with-windows=yes \
     --daemon=no \
     --clipboard=yes \
-    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 ${XPRA_INITIAL_RESOLUTION}x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
+    --xvfb="Xvfb" \
     $DISPLAY \
-    2>/tmp/xpra.log | tee --append /tmp/xpra.log
+    2>"$XPRA_LOG" | tee --append "$XPRA_LOG"

--- a/qupath_plus_051.def
+++ b/qupath_plus_051.def
@@ -77,12 +77,16 @@ From: amd64/ubuntu:jammy
     chmod 700 $HOME/.xpra
     export XDG_RUNTIME_DIR=$HOME/.xpra
     export DISPLAY=:$(shuf -n 1 -i 100-200)
+    export XAUTHORITY="${HOME}/.Xauthority"
+    xauth add ${DISPLAY} . "$(mcookie)"
+    export XPRA_INITIAL_RESOLUTION="${XPRA_INITIAL_RESOLUTION:-1920x1080}"
     while PORT=$(shuf -n 1 -i 49152-65535); nc -z 0.0.0.0 $PORT; do continue; done
     export XPRA_PASSWORD=$(uuidgen)
     echo "========================================="
     echo "Password is $XPRA_PASSWORD"
     echo "Launching QuPath to display via Xpra on DISPLAY $DISPLAY. Connect via"
     echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
+    echo "Initial Xpra display size is $XPRA_INITIAL_RESOLUTION and it will resize to the client."
     echo "Logging errors to /tmp/xpra.log"
     echo "========================================="
     xpra start \
@@ -92,11 +96,12 @@ From: amd64/ubuntu:jammy
     --socket-dirs=$XDG_RUNTIME_DIR \
     --opengl=yes \
     --html=on \
+    --resize-display=$XPRA_INITIAL_RESOLUTION \
     --compression-level=1 \
     --start="/QuPath/bin/QuPath" \
     --exit-with-windows=yes \
     --daemon=no \
     --clipboard=yes \
-    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
+    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 ${XPRA_INITIAL_RESOLUTION}x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
     $DISPLAY \
     2>/tmp/xpra.log | tee --append /tmp/xpra.log

--- a/qupath_plus_051.def
+++ b/qupath_plus_051.def
@@ -89,22 +89,23 @@ From: amd64/ubuntu:jammy
     echo "Logging errors to $XPRA_LOG"
     echo "========================================="
     xpra start \
-    --minimal=yes \
     --bind-tcp=0.0.0.0:$PORT,auth=env \
-    --websocket-upgrade=yes \
+    --mdns=no \
     --socket-dirs=$XDG_RUNTIME_DIR \
-    --opengl=yes \
     --html=on \
     --resize-display=yes \
-    --compression-level=1 \
-    --pings=5 \
-    --encodings=rgb,png,jpeg,webp \
-    --mousewheel=on \
-    --cursors=yes \
+    --dpi=96 \
+    --file-transfer=no \
+    --open-files=no \
+    --open-url=no \
+    --printing=no \
+    --webcam=no \
+    --notifications=no \
+    --system-tray=no \
+    --audio=no \
     --start-child-after-connect="/QuPath/bin/QuPath" \
     --exit-with-windows=yes \
     --daemon=no \
-    --clipboard=yes \
     --xvfb="Xvfb" \
     $DISPLAY \
     2>"$XPRA_LOG" | tee --append "$XPRA_LOG"

--- a/qupath_xpra.def
+++ b/qupath_xpra.def
@@ -44,20 +44,19 @@ From: amd64/ubuntu:jammy
     #!/bin/bash
     # setup secure DISPLAY
     export DISPLAY=:$(shuf -n 1 -i 100-200)
-    export XAUTHORITY="${HOME}/.Xauthority"
-    xauth add ${DISPLAY} . "$(mcookie)"
     mkdir -p $HOME/.xpra
     chmod 700 $HOME/.xpra
     export XDG_RUNTIME_DIR=$HOME/.xpra
-    export XPRA_INITIAL_RESOLUTION="${XPRA_INITIAL_RESOLUTION:-1920x1080}"
+    export XPRA_PRIVATE_XAUTH=1
+    export XPRA_LOG="$XDG_RUNTIME_DIR/xpra-qupath.log"
     while PORT=$(shuf -n 1 -i 49152-65535); nc -z 0.0.0.0 $PORT; do continue; done
     export XPRA_PASSWORD=$(uuidgen)
     echo "========================================="
     echo "Password is $XPRA_PASSWORD"
     echo "Launching QuPath to display via Xpra on DISPLAY $DISPLAY. Connect via"
     echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
-    echo "Initial Xpra display size is $XPRA_INITIAL_RESOLUTION and it will resize to the client."
-    echo "Logging errors to /tmp/xpra.log"
+    echo "QuPath will start after the first client connects so the display can size to the browser."
+    echo "Logging errors to $XPRA_LOG"
     echo "========================================="
     xpra start \
     --minimal=yes \
@@ -66,12 +65,16 @@ From: amd64/ubuntu:jammy
     --socket-dirs=$XDG_RUNTIME_DIR \
     --opengl=yes \
     --html=on \
-    --resize-display=$XPRA_INITIAL_RESOLUTION \
+    --resize-display=yes \
     --compression-level=1 \
-    --start="/QuPath/bin/QuPath" \
+    --pings=5 \
+    --encodings=rgb,png,jpeg,webp \
+    --mousewheel=on \
+    --cursors=yes \
+    --start-child-after-connect="/QuPath/bin/QuPath" \
     --exit-with-windows=yes \
     --daemon=no \
     --clipboard=yes \
-    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 ${XPRA_INITIAL_RESOLUTION}x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
+    --xvfb="Xvfb" \
     $DISPLAY \
-    2>/tmp/xpra.log | tee --append /tmp/xpra.log
+    2>"$XPRA_LOG" | tee --append "$XPRA_LOG"

--- a/qupath_xpra.def
+++ b/qupath_xpra.def
@@ -49,12 +49,14 @@ From: amd64/ubuntu:jammy
     mkdir -p $HOME/.xpra
     chmod 700 $HOME/.xpra
     export XDG_RUNTIME_DIR=$HOME/.xpra
+    export XPRA_INITIAL_RESOLUTION="${XPRA_INITIAL_RESOLUTION:-1920x1080}"
     while PORT=$(shuf -n 1 -i 49152-65535); nc -z 0.0.0.0 $PORT; do continue; done
     export XPRA_PASSWORD=$(uuidgen)
     echo "========================================="
     echo "Password is $XPRA_PASSWORD"
     echo "Launching QuPath to display via Xpra on DISPLAY $DISPLAY. Connect via"
     echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
+    echo "Initial Xpra display size is $XPRA_INITIAL_RESOLUTION and it will resize to the client."
     echo "Logging errors to /tmp/xpra.log"
     echo "========================================="
     xpra start \
@@ -64,11 +66,12 @@ From: amd64/ubuntu:jammy
     --socket-dirs=$XDG_RUNTIME_DIR \
     --opengl=yes \
     --html=on \
+    --resize-display=$XPRA_INITIAL_RESOLUTION \
     --compression-level=1 \
     --start="/QuPath/bin/QuPath" \
     --exit-with-windows=yes \
     --daemon=no \
     --clipboard=yes \
-    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
+    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 ${XPRA_INITIAL_RESOLUTION}x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
     $DISPLAY \
     2>/tmp/xpra.log | tee --append /tmp/xpra.log

--- a/qupath_xpra.def
+++ b/qupath_xpra.def
@@ -59,22 +59,23 @@ From: amd64/ubuntu:jammy
     echo "Logging errors to $XPRA_LOG"
     echo "========================================="
     xpra start \
-    --minimal=yes \
     --bind-tcp=0.0.0.0:$PORT,auth=env \
-    --websocket-upgrade=yes \
+    --mdns=no \
     --socket-dirs=$XDG_RUNTIME_DIR \
-    --opengl=yes \
     --html=on \
     --resize-display=yes \
-    --compression-level=1 \
-    --pings=5 \
-    --encodings=rgb,png,jpeg,webp \
-    --mousewheel=on \
-    --cursors=yes \
+    --dpi=96 \
+    --file-transfer=no \
+    --open-files=no \
+    --open-url=no \
+    --printing=no \
+    --webcam=no \
+    --notifications=no \
+    --system-tray=no \
+    --audio=no \
     --start-child-after-connect="/QuPath/bin/QuPath" \
     --exit-with-windows=yes \
     --daemon=no \
-    --clipboard=yes \
     --xvfb="Xvfb" \
     $DISPLAY \
     2>"$XPRA_LOG" | tee --append "$XPRA_LOG"

--- a/slicer_xpra.def
+++ b/slicer_xpra.def
@@ -35,21 +35,20 @@ From: amd64/ubuntu:jammy
     #!/bin/bash
     # setup secure DISPLAY
     export DISPLAY=:$(shuf -n 1 -i 100-200)
-    export XAUTHORITY="${HOME}/.Xauthority"
-    xauth add ${DISPLAY} . "$(mcookie)"
     mkdir -p $HOME/.xpra
     chmod 700 $HOME/.xpra
     export XDG_RUNTIME_DIR=$HOME/.xpra
-    export XPRA_INITIAL_RESOLUTION="${XPRA_INITIAL_RESOLUTION:-1920x1080}"
+    export XPRA_PRIVATE_XAUTH=1
+    export XPRA_LOG="$XDG_RUNTIME_DIR/xpra-slicer.log"
     while PORT=$(shuf -n 1 -i 49152-65535); nc -z 0.0.0.0 $PORT; do continue; done
     export XPRA_PASSWORD=$(uuidgen)
     echo "========================================="
     echo "Password is $XPRA_PASSWORD"
     echo "Launching Slicer to display via Xpra on DISPLAY $DISPLAY. Connect via"
     echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
-    echo "Initial Xpra display size is $XPRA_INITIAL_RESOLUTION and it will resize to the client."
+    echo "Slicer will start after the first client connects so the display can size to the browser."
     echo "Please be patient; there will be no splash screen."
-    echo "Logging errors to /tmp/xpra.log"
+    echo "Logging errors to $XPRA_LOG"
     echo "========================================="
     xpra start \
     --minimal=yes \
@@ -58,12 +57,16 @@ From: amd64/ubuntu:jammy
     --socket-dirs=$XDG_RUNTIME_DIR \
     --opengl=yes \
     --html=on \
-    --resize-display=$XPRA_INITIAL_RESOLUTION \
+    --resize-display=yes \
     --compression-level=1 \
-    --start="/Slicer-5.8.1-linux-amd64/Slicer --no-splash" \
+    --pings=5 \
+    --encodings=rgb,png,jpeg,webp \
+    --mousewheel=on \
+    --cursors=yes \
+    --start-child-after-connect="/Slicer-5.8.1-linux-amd64/Slicer --no-splash" \
     --exit-with-windows=yes \
     --daemon=no \
     --clipboard=yes \
-    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 ${XPRA_INITIAL_RESOLUTION}x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
+    --xvfb="Xvfb" \
     $DISPLAY \
-    2>/tmp/xpra.log | tee --append /tmp/xpra.log
+    2>"$XPRA_LOG" | tee --append "$XPRA_LOG"

--- a/slicer_xpra.def
+++ b/slicer_xpra.def
@@ -40,12 +40,14 @@ From: amd64/ubuntu:jammy
     mkdir -p $HOME/.xpra
     chmod 700 $HOME/.xpra
     export XDG_RUNTIME_DIR=$HOME/.xpra
+    export XPRA_INITIAL_RESOLUTION="${XPRA_INITIAL_RESOLUTION:-1920x1080}"
     while PORT=$(shuf -n 1 -i 49152-65535); nc -z 0.0.0.0 $PORT; do continue; done
     export XPRA_PASSWORD=$(uuidgen)
     echo "========================================="
     echo "Password is $XPRA_PASSWORD"
     echo "Launching Slicer to display via Xpra on DISPLAY $DISPLAY. Connect via"
     echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
+    echo "Initial Xpra display size is $XPRA_INITIAL_RESOLUTION and it will resize to the client."
     echo "Please be patient; there will be no splash screen."
     echo "Logging errors to /tmp/xpra.log"
     echo "========================================="
@@ -56,12 +58,12 @@ From: amd64/ubuntu:jammy
     --socket-dirs=$XDG_RUNTIME_DIR \
     --opengl=yes \
     --html=on \
+    --resize-display=$XPRA_INITIAL_RESOLUTION \
     --compression-level=1 \
     --start="/Slicer-5.8.1-linux-amd64/Slicer --no-splash" \
     --exit-with-windows=yes \
     --daemon=no \
     --clipboard=yes \
-    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
+    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 ${XPRA_INITIAL_RESOLUTION}x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
     $DISPLAY \
     2>/tmp/xpra.log | tee --append /tmp/xpra.log
-

--- a/slicer_xpra.def
+++ b/slicer_xpra.def
@@ -51,22 +51,23 @@ From: amd64/ubuntu:jammy
     echo "Logging errors to $XPRA_LOG"
     echo "========================================="
     xpra start \
-    --minimal=yes \
     --bind-tcp=0.0.0.0:$PORT,auth=env \
-    --websocket-upgrade=yes \
+    --mdns=no \
     --socket-dirs=$XDG_RUNTIME_DIR \
-    --opengl=yes \
     --html=on \
     --resize-display=yes \
-    --compression-level=1 \
-    --pings=5 \
-    --encodings=rgb,png,jpeg,webp \
-    --mousewheel=on \
-    --cursors=yes \
+    --dpi=96 \
+    --file-transfer=no \
+    --open-files=no \
+    --open-url=no \
+    --printing=no \
+    --webcam=no \
+    --notifications=no \
+    --system-tray=no \
+    --audio=no \
     --start-child-after-connect="/Slicer-5.8.1-linux-amd64/Slicer --no-splash" \
     --exit-with-windows=yes \
     --daemon=no \
-    --clipboard=yes \
     --xvfb="Xvfb" \
     $DISPLAY \
     2>"$XPRA_LOG" | tee --append "$XPRA_LOG"

--- a/xpra_latest.def
+++ b/xpra_latest.def
@@ -29,6 +29,7 @@ From: amd64/ubuntu:jammy
     mkdir -p $HOME/.xpra
     chmod 700 $HOME/.xpra
     export XDG_RUNTIME_DIR=$HOME/.xpra
+    export XPRA_INITIAL_RESOLUTION="${XPRA_INITIAL_RESOLUTION:-1920x1080}"
     while PORT=$(shuf -n 1 -i 49152-65535); nc -z 0.0.0.0 $PORT; do continue; done
     export XPRA_PASSWORD=$(uuidgen)
     echo "========================================="
@@ -39,6 +40,7 @@ From: amd64/ubuntu:jammy
     echo "DISPLAY=$DISPLAY xterm" 
     echo "Connect to Xpra display via web browser at"
     echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
+    echo "Initial Xpra display size is $XPRA_INITIAL_RESOLUTION and it will resize to the client."
     echo "or using Xpra client"
     echo "xpra attach tcp://$USER:$XPRA_PASSWORD@$(hostname -i):$PORT"
     echo "Logging errors to /tmp/xpra.log"
@@ -50,10 +52,11 @@ From: amd64/ubuntu:jammy
     --socket-dirs=$XDG_RUNTIME_DIR \
     --opengl=yes \
     --html=on \
+    --resize-display=$XPRA_INITIAL_RESOLUTION \
     --compression-level=1 \
     --daemon=no \
     --start="xterm" \
     --clipboard=yes \
-    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
+    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 ${XPRA_INITIAL_RESOLUTION}x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
     $DISPLAY \
     2>/tmp/xpra.log | tee --append /tmp/xpra.log

--- a/xpra_latest.def
+++ b/xpra_latest.def
@@ -24,12 +24,11 @@ From: amd64/ubuntu:jammy
     #!/bin/bash
     # setup secure DISPLAY
     export DISPLAY=:$(shuf -n 1 -i 100-200)
-    export XAUTHORITY="${HOME}/.Xauthority"
-    xauth add ${DISPLAY} . "$(mcookie)"
     mkdir -p $HOME/.xpra
     chmod 700 $HOME/.xpra
     export XDG_RUNTIME_DIR=$HOME/.xpra
-    export XPRA_INITIAL_RESOLUTION="${XPRA_INITIAL_RESOLUTION:-1920x1080}"
+    export XPRA_PRIVATE_XAUTH=1
+    export XPRA_LOG="$XDG_RUNTIME_DIR/xpra-xterm.log"
     while PORT=$(shuf -n 1 -i 49152-65535); nc -z 0.0.0.0 $PORT; do continue; done
     export XPRA_PASSWORD=$(uuidgen)
     echo "========================================="
@@ -40,10 +39,10 @@ From: amd64/ubuntu:jammy
     echo "DISPLAY=$DISPLAY xterm" 
     echo "Connect to Xpra display via web browser at"
     echo "http://$(hostname -i):$PORT/?password=$XPRA_PASSWORD"
-    echo "Initial Xpra display size is $XPRA_INITIAL_RESOLUTION and it will resize to the client."
+    echo "The xterm will start after the first client connects so the display can size to the browser."
     echo "or using Xpra client"
     echo "xpra attach tcp://$USER:$XPRA_PASSWORD@$(hostname -i):$PORT"
-    echo "Logging errors to /tmp/xpra.log"
+    echo "Logging errors to $XPRA_LOG"
     echo "========================================="
     xpra start \
     --minimal=yes \
@@ -52,11 +51,15 @@ From: amd64/ubuntu:jammy
     --socket-dirs=$XDG_RUNTIME_DIR \
     --opengl=yes \
     --html=on \
-    --resize-display=$XPRA_INITIAL_RESOLUTION \
+    --resize-display=yes \
     --compression-level=1 \
+    --pings=5 \
+    --encodings=rgb,png,jpeg,webp \
+    --mousewheel=on \
+    --cursors=yes \
     --daemon=no \
-    --start="xterm" \
+    --start-child-after-connect="xterm" \
     --clipboard=yes \
-    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 ${XPRA_INITIAL_RESOLUTION}x24+32 -nolisten tcp -noreset -auth $XAUTHORITY" \
+    --xvfb="Xvfb" \
     $DISPLAY \
-    2>/tmp/xpra.log | tee --append /tmp/xpra.log
+    2>"$XPRA_LOG" | tee --append "$XPRA_LOG"

--- a/xpra_latest.def
+++ b/xpra_latest.def
@@ -45,21 +45,22 @@ From: amd64/ubuntu:jammy
     echo "Logging errors to $XPRA_LOG"
     echo "========================================="
     xpra start \
-    --minimal=yes \
     --bind-tcp=0.0.0.0:$PORT,auth=env \
-    --websocket-upgrade=yes \
+    --mdns=no \
     --socket-dirs=$XDG_RUNTIME_DIR \
-    --opengl=yes \
     --html=on \
     --resize-display=yes \
-    --compression-level=1 \
-    --pings=5 \
-    --encodings=rgb,png,jpeg,webp \
-    --mousewheel=on \
-    --cursors=yes \
+    --dpi=96 \
+    --file-transfer=no \
+    --open-files=no \
+    --open-url=no \
+    --printing=no \
+    --webcam=no \
+    --notifications=no \
+    --system-tray=no \
+    --audio=no \
     --daemon=no \
     --start-child-after-connect="xterm" \
-    --clipboard=yes \
     --xvfb="Xvfb" \
     $DISPLAY \
     2>"$XPRA_LOG" | tee --append "$XPRA_LOG"


### PR DESCRIPTION
There's less going on here than it seems.
The main things are:
1. let xpra handle the x11 magic cookie stuff, using `export XPRA_PRIVATE_XAUTH=1`
2. log to a local (user home directory) with the app name appended, so logs can be more easily checked. Also prevents issues if two users have the same node and same /tmp
3. use `--resize-display` and let xpra handle the Xvfb setup. This is to handle people with large or small monitors. This requires `--start-child-after-connect` such that the connection is established and then the app is launched. Note: when using --minimal this resulted in two apps spawned, which appears to be an xpra bug. Switched to using defaults and then explicitly setting `no` on things we want off